### PR TITLE
fixed missing include needed for sleep()

### DIFF
--- a/cob_sick_lms1xx/common/src/test.cpp
+++ b/cob_sick_lms1xx/common/src/test.cpp
@@ -24,6 +24,7 @@
 #include "lms1xx.h"
 
 #include <iostream>
+#include <unistd.h>
 
 int main()
 {


### PR DESCRIPTION
fixed issue #6 in mas_domestic_robotics. please test on a second machine.
